### PR TITLE
支持容器（container）

### DIFF
--- a/pydis/core.py
+++ b/pydis/core.py
@@ -36,6 +36,8 @@ class Pydis(metaclass=SingletonType):
             return None
         return value.value
 
+    __getitem__ = get
+
     def set_nx(self, key: str, value: Any, timeout: Optional[int] = None) -> bool:
         """
         没有key的时候设置key，返回True
@@ -55,11 +57,15 @@ class Pydis(metaclass=SingletonType):
         value = Value(value, timeout=timeout)
         self._data[key] = value
 
+    __setitem__ = _set
+
     def delete(self, key: str) -> None:
         try:
             del self._data[key]
         except (NotFound, ExpiredError):
             return None
+
+    __delitem__ = delete
 
     def ttl(self, key: str) -> int:
         """
@@ -116,3 +122,8 @@ class Pydis(metaclass=SingletonType):
 
     def __len__(self) -> int:
         return len(self._data)
+
+    __contains__ = _data.__contains__
+
+    def __iter__(self):
+        return self._data

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -96,3 +96,17 @@ class TestCore(TestCase):
         p = Pydis()
         p.force_clean()
         self.assertEqual(len(p), 0)
+
+    def test_container(self):
+        p = Pydis()
+        p.force_clean()
+        test_data = {'o': 1, 'l':23, '?':443, '`': 8}
+        p.set_many(test_data)
+        for k, v in enumerate(p):
+            self.assertEqual(test_data[k], v)
+            self.assertEqual(p[k], v)
+            self.asserIn(k, p)
+        p['o'] = 33
+        self.assertEqual(p['o'], 33)
+        del p['?']
+        self.assertNotIn('?', p)


### PR DESCRIPTION
支持下列用法
```python
from pydis import Pydis
manager = Pydis()

manager.set_many({'key1': 'value1', 'key2': 'value2', 'key3': 'value3'})

for k, v in enumerate(manager):
    print(k, manager[k], v)
del manager['key1']
manager['key4'] = 'value4'
```