### PR TITLE
test: fix the influence of singleton on test cases

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -119,3 +119,6 @@ class TestCore(TestCase):
         p.load('test_save_load.pkl', nx=True)
         self.assertEqual(p.get('a'), 2)
         self.assertEqual(p.get('b')(1), 1)
+
+    def tearDown(self):
+        Pydis._instance = None


### PR DESCRIPTION
Pydis 使用单例模式导致上一个测试用例的操作会对下一个产生影响